### PR TITLE
When populating from file, prevent selecting already selected button.

### DIFF
--- a/sample/classes/Radio.py
+++ b/sample/classes/Radio.py
@@ -115,10 +115,11 @@ class GuiRadio(FrameBaseClass):
         self.arg_set(option_text)
 
     def set_string(self, value):
-        super().set_string(value)
-        self.verbose = not self.verbose
-        self.select(value)
-        self.verbose = not self.verbose
+        if self.string_var.get() != value:
+            super().set_string(value)
+            self.verbose = not self.verbose
+            self.select(value)
+            self.verbose = not self.verbose
 
     def set_type_of(self):
         self.parent.arg_dict['type_of'] = 'share' if self.parent.arg_dict['asset_type'] == 'stock' else 'coin'

--- a/sample/interface.py
+++ b/sample/interface.py
@@ -219,7 +219,7 @@ class GUI(Frame):
                 'type': 'Currency',
             },
             {  # Allotted Money Frame
-                'description': 'Enter the amount you willing to spend today.',
+                'description': 'Enter the amount you\'re willing to spend.',
                 'frame_var': None,
                 'index': 6,
                 'key': 'allotted_money',


### PR DESCRIPTION
When switching from A (stock) to B (stock), prevent de-selecting the asset_type Radiobuttons.
 - Caused all Frames below Asset Type Frame to be destroyed.

Fixed a typo in the Allotted Money Entry description.